### PR TITLE
add another case-specific test

### DIFF
--- a/src/test/java/com/casetext/hashes/fnv/FNVTest.java
+++ b/src/test/java/com/casetext/hashes/fnv/FNVTest.java
@@ -21,5 +21,6 @@ public class FNVTest {
         assertEquals("'marcavage-v-rendell-1'", "AFQf-getQ3eEDgNGTCPs5A", FNV.hash("marcavage-v-rendell-1"));
         assertEquals("'ca-health-and-saf-code-131085-fire-protection-building-standards-for-roofs-exterior-walls-structure-projections-and-structure-openings-in-fire-hazard-severity-zones'", "AEX2IfHegD0_PKTfaBPEsQ", FNV.hash("ca-health-and-saf-code-131085-fire-protection-building-standards-for-roofs-exterior-walls-structure-projections-and-structure-openings-in-fire-hazard-severity-zones"));
         assertEquals("'matter-of-mazzella-v-sullivan'", "AApjVduDdtxmJfUQOWZlTQ", FNV.hash("matter-of-mazzella-v-sullivan"));
+        assertEquals("'trs-the-v-francis-a-lee-matt-con-servs-corp'", "AAyWLQaozsR6L3XQs0Nt_g", FNV.hash("trs-the-v-francis-a-lee-matt-con-servs-corp"));
     }
 }


### PR DESCRIPTION
Adds a test for `trs-the-v-francis-a-lee-matt-con-servs-corp`

We had a problem with it, but it turned out that the problem was with jitpack keeping old artifacts in cache.